### PR TITLE
Change TYPE_MAPPER from an array to a perfect hash map

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/CorentinDeblock/wrld"
 [lib]
 proc_macro = true
 
-[dev_dependencies]
+[dev-dependencies]
 trybuild = {version = "1.0", features = ["diff"]}
 
 [dependencies]
@@ -26,3 +26,4 @@ proc-macro2 = "1.0.43"
 wgpu = "0.13.1"
 bytemuck = { version = "1.4", features = [ "derive" ] }
 regex = "1.6.0"
+phf = {version = "0.11", features = ["macros"]}

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -1,3 +1,5 @@
+use phf::phf_map;
+
 const F16 : usize = 2;
 
 #[derive(Copy, Clone, Debug)]
@@ -12,48 +14,46 @@ pub struct WGPUData {
     pub shader_location: u32
 }
 
-const TYPE_MAPPER : [(&str, TypeToWGPU); 34] = [
-    ("u32", TypeToWGPU { offset: std::mem::size_of::<u32>() as u64, ty: wgpu::VertexFormat::Uint32 }),
-    ("f32", TypeToWGPU { offset: std::mem::size_of::<f32>() as u64, ty: wgpu::VertexFormat::Float32 }),
-    ("s32", TypeToWGPU { offset: std::mem::size_of::<i32>() as u64, ty: wgpu::VertexFormat::Sint32 }),
-    ("f64", TypeToWGPU { offset: std::mem::size_of::<f64>() as u64, ty: wgpu::VertexFormat::Float64 }),
-    ("u8x2", TypeToWGPU { offset: std::mem::size_of::<[u8; 2]>() as u64, ty: wgpu::VertexFormat::Uint8x2 }),
-    ("u8x4", TypeToWGPU { offset: std::mem::size_of::<[u8; 4]>() as u64, ty: wgpu::VertexFormat::Uint8x4 }),
-    ("s8x2", TypeToWGPU { offset: std::mem::size_of::<[i8; 2]>() as u64, ty: wgpu::VertexFormat::Sint8x2 }),
-    ("s8x4", TypeToWGPU { offset: std::mem::size_of::<[i8; 4]>() as u64, ty: wgpu::VertexFormat::Sint8x4 }),
-    ("un8x2", TypeToWGPU { offset: std::mem::size_of::<[u8; 2]>() as u64, ty: wgpu::VertexFormat::Unorm8x2 }),
-    ("un8x4", TypeToWGPU { offset: std::mem::size_of::<[u8; 4]>() as u64, ty: wgpu::VertexFormat::Unorm8x4 }),
-    ("sn8x2", TypeToWGPU { offset: std::mem::size_of::<[i8; 2]>() as u64, ty: wgpu::VertexFormat::Snorm8x2 }),
-    ("sn8x4", TypeToWGPU { offset: std::mem::size_of::<[i8; 4]>() as u64, ty: wgpu::VertexFormat::Snorm8x4 }),
-    ("u16x2", TypeToWGPU { offset: std::mem::size_of::<[u16; 2]>() as u64, ty: wgpu::VertexFormat::Uint16x2 }),
-    ("u16x4", TypeToWGPU { offset: std::mem::size_of::<[u16; 4]>() as u64, ty: wgpu::VertexFormat::Uint16x4 }),
-    ("s16x2", TypeToWGPU { offset: std::mem::size_of::<[i16; 2]>() as u64, ty: wgpu::VertexFormat::Sint16x2 }),
-    ("s16x4", TypeToWGPU { offset: std::mem::size_of::<[i16; 4]>() as u64, ty: wgpu::VertexFormat::Sint16x4 }),
-    ("un16x2", TypeToWGPU { offset: std::mem::size_of::<[u16; 2]>() as u64, ty: wgpu::VertexFormat::Unorm16x2 }),
-    ("un16x4", TypeToWGPU { offset: std::mem::size_of::<[u16; 4]>() as u64, ty: wgpu::VertexFormat::Unorm16x4 }),
-    ("sn16x2", TypeToWGPU { offset: std::mem::size_of::<[i16; 2]>() as u64, ty: wgpu::VertexFormat::Snorm16x2 }),
-    ("sn16x4", TypeToWGPU { offset: std::mem::size_of::<[i16; 4]>() as u64, ty: wgpu::VertexFormat::Snorm16x4 }),
-    ("f16x2", TypeToWGPU { offset: (F16 * 2) as u64, ty: wgpu::VertexFormat::Float16x2 }),
-    ("f16x4", TypeToWGPU { offset: (F16 * 4) as u64, ty: wgpu::VertexFormat::Float16x4 }),
-    ("f32x2", TypeToWGPU { offset: std::mem::size_of::<[f32; 2]>() as u64, ty: wgpu::VertexFormat::Float32x2 }),
-    ("f32x3", TypeToWGPU { offset: std::mem::size_of::<[f32; 3]>() as u64, ty: wgpu::VertexFormat::Float32x3 }),
-    ("f32x4", TypeToWGPU { offset: std::mem::size_of::<[f32; 4]>() as u64, ty: wgpu::VertexFormat::Float32x4 }),
-    ("u32x2", TypeToWGPU { offset: std::mem::size_of::<[u32; 2]>() as u64, ty: wgpu::VertexFormat::Uint32x2 }),
-    ("u32x3", TypeToWGPU { offset: std::mem::size_of::<[u32; 3]>() as u64, ty: wgpu::VertexFormat::Uint32x3 }),
-    ("u32x4", TypeToWGPU { offset: std::mem::size_of::<[u32; 4]>() as u64, ty: wgpu::VertexFormat::Uint32x4 }),
-    ("s32x2", TypeToWGPU { offset: std::mem::size_of::<[i32; 2]>() as u64, ty: wgpu::VertexFormat::Sint32x2 }),
-    ("s32x3", TypeToWGPU { offset: std::mem::size_of::<[i32; 3]>() as u64, ty: wgpu::VertexFormat::Sint32x3 }),
-    ("s32x4", TypeToWGPU { offset: std::mem::size_of::<[i32; 4]>() as u64, ty: wgpu::VertexFormat::Sint32x4 }),
-    ("f64x2", TypeToWGPU { offset: std::mem::size_of::<[f64; 2]>() as u64, ty: wgpu::VertexFormat::Float64x2 }),
-    ("f64x3", TypeToWGPU { offset: std::mem::size_of::<[f32; 3]>() as u64, ty: wgpu::VertexFormat::Float64x3 }),
-    ("f64x4", TypeToWGPU { offset: std::mem::size_of::<[f64; 4]>() as u64, ty: wgpu::VertexFormat::Float64x4 })
-];
+static TYPE_MAPPER : phf::Map<&'static str, TypeToWGPU> = phf_map! {
+    "u32" => TypeToWGPU { offset: std::mem::size_of::<u32>() as u64, ty: wgpu::VertexFormat::Uint32 },
+    "f32" => TypeToWGPU { offset: std::mem::size_of::<f32>() as u64, ty: wgpu::VertexFormat::Float32 },
+    "s32" => TypeToWGPU { offset: std::mem::size_of::<i32>() as u64, ty: wgpu::VertexFormat::Sint32 },
+    "f64" => TypeToWGPU { offset: std::mem::size_of::<f64>() as u64, ty: wgpu::VertexFormat::Float64 },
+    "u8x2" => TypeToWGPU { offset: std::mem::size_of::<[u8; 2]>() as u64, ty: wgpu::VertexFormat::Uint8x2 },
+    "u8x4" => TypeToWGPU { offset: std::mem::size_of::<[u8; 4]>() as u64, ty: wgpu::VertexFormat::Uint8x4 },
+    "s8x2" => TypeToWGPU { offset: std::mem::size_of::<[i8; 2]>() as u64, ty: wgpu::VertexFormat::Sint8x2 },
+    "s8x4" => TypeToWGPU { offset: std::mem::size_of::<[i8; 4]>() as u64, ty: wgpu::VertexFormat::Sint8x4 },
+    "un8x2" => TypeToWGPU { offset: std::mem::size_of::<[u8; 2]>() as u64, ty: wgpu::VertexFormat::Unorm8x2 },
+    "un8x4" => TypeToWGPU { offset: std::mem::size_of::<[u8; 4]>() as u64, ty: wgpu::VertexFormat::Unorm8x4 },
+    "sn8x2" => TypeToWGPU { offset: std::mem::size_of::<[i8; 2]>() as u64, ty: wgpu::VertexFormat::Snorm8x2 },
+    "sn8x4" => TypeToWGPU { offset: std::mem::size_of::<[i8; 4]>() as u64, ty: wgpu::VertexFormat::Snorm8x4 },
+    "u16x2" => TypeToWGPU { offset: std::mem::size_of::<[u16; 2]>() as u64, ty: wgpu::VertexFormat::Uint16x2 },
+    "u16x4" => TypeToWGPU { offset: std::mem::size_of::<[u16; 4]>() as u64, ty: wgpu::VertexFormat::Uint16x4 },
+    "s16x2" => TypeToWGPU { offset: std::mem::size_of::<[i16; 2]>() as u64, ty: wgpu::VertexFormat::Sint16x2 },
+    "s16x4" => TypeToWGPU { offset: std::mem::size_of::<[i16; 4]>() as u64, ty: wgpu::VertexFormat::Sint16x4 },
+    "un16x2" => TypeToWGPU { offset: std::mem::size_of::<[u16; 2]>() as u64, ty: wgpu::VertexFormat::Unorm16x2 },
+    "un16x4" => TypeToWGPU { offset: std::mem::size_of::<[u16; 4]>() as u64, ty: wgpu::VertexFormat::Unorm16x4 },
+    "sn16x2" => TypeToWGPU { offset: std::mem::size_of::<[i16; 2]>() as u64, ty: wgpu::VertexFormat::Snorm16x2 },
+    "sn16x4" => TypeToWGPU { offset: std::mem::size_of::<[i16; 4]>() as u64, ty: wgpu::VertexFormat::Snorm16x4 },
+    "f16x2" => TypeToWGPU { offset: (F16 * 2) as u64, ty: wgpu::VertexFormat::Float16x2 },
+    "f16x4" => TypeToWGPU { offset: (F16 * 4) as u64, ty: wgpu::VertexFormat::Float16x4 },
+    "f32x2" => TypeToWGPU { offset: std::mem::size_of::<[f32; 2]>() as u64, ty: wgpu::VertexFormat::Float32x2 },
+    "f32x3" => TypeToWGPU { offset: std::mem::size_of::<[f32; 3]>() as u64, ty: wgpu::VertexFormat::Float32x3 },
+    "f32x4" => TypeToWGPU { offset: std::mem::size_of::<[f32; 4]>() as u64, ty: wgpu::VertexFormat::Float32x4 },
+    "u32x2" => TypeToWGPU { offset: std::mem::size_of::<[u32; 2]>() as u64, ty: wgpu::VertexFormat::Uint32x2 },
+    "u32x3" => TypeToWGPU { offset: std::mem::size_of::<[u32; 3]>() as u64, ty: wgpu::VertexFormat::Uint32x3 },
+    "u32x4" => TypeToWGPU { offset: std::mem::size_of::<[u32; 4]>() as u64, ty: wgpu::VertexFormat::Uint32x4 },
+    "s32x2" => TypeToWGPU { offset: std::mem::size_of::<[i32; 2]>() as u64, ty: wgpu::VertexFormat::Sint32x2 },
+    "s32x3" => TypeToWGPU { offset: std::mem::size_of::<[i32; 3]>() as u64, ty: wgpu::VertexFormat::Sint32x3 },
+    "s32x4" => TypeToWGPU { offset: std::mem::size_of::<[i32; 4]>() as u64, ty: wgpu::VertexFormat::Sint32x4 },
+    "f64x2" => TypeToWGPU { offset: std::mem::size_of::<[f64; 2]>() as u64, ty: wgpu::VertexFormat::Float64x2 },
+    "f64x3" => TypeToWGPU { offset: std::mem::size_of::<[f32; 3]>() as u64, ty: wgpu::VertexFormat::Float64x3 },
+    "f64x4" => TypeToWGPU { offset: std::mem::size_of::<[f64; 4]>() as u64, ty: wgpu::VertexFormat::Float64x4 }
+};
 
 fn get_type(name: &str) -> Result<TypeToWGPU, String> {
-    for i in TYPE_MAPPER {
-        if i.0 == name {
-            return Ok(i.1)
-        }
+    if let Some(typ) = TYPE_MAPPER.get(name) {
+        return Ok(*typ)
     }
 
     Err(format!("Cannot get type for {:?}", name))
@@ -61,9 +61,9 @@ fn get_type(name: &str) -> Result<TypeToWGPU, String> {
 
 pub fn get_allowed_type(name: &str) -> std::vec::Vec<&str> {
     let mut vec: std::vec::Vec::<&str> = std::vec::Vec::new();
-    for i in TYPE_MAPPER {
-        if i.0.contains(name) {
-            vec.push(i.0);
+    for i in TYPE_MAPPER.keys() {
+        if i.contains(name) {
+            vec.push(i);
         }
     }
     vec
@@ -99,10 +99,5 @@ pub fn convert_type_to_wgpu(name: &String, shader_location: u32) -> Result<WGPUD
 }
 
 pub fn has_type(name: &str) -> bool {
-    for i in TYPE_MAPPER {
-        if i.0 == name {
-            return true
-        }
-    }
-    false
+    TYPE_MAPPER.contains_key(name)
 }


### PR DESCRIPTION
- Added the 'phf' crate as a dependency
- In converter.rs, TYPE_MAPPER is now a phf::Map (compile-time map)

This allows for O(1) searching instead of O(log n). Iterating over a 34-element array each time could potentially slow down build times on projects with a very large number of buffers. `phf::Map`s  are compile time maps made for this kind of case.

NB: Untested, since sadly this crate does not yet have any tests and another issue prevents me from making tests easily (I might open a github issue later). I ask the crate's author to test this.

NB2: I strongly suggest using `cargo fmt` on the code. [Rust has a standard code style for good reasons](https://github.com/rust-lang/style-team/blob/master/guide/guide.md).
I did not do it on this PR to not clutter the diff view.

NB3: I tend to write PRs in a cold and formal way, but this is a very cool crate :) Keep it up